### PR TITLE
feat: improve skill scores for gemini-cli-modes

### DIFF
--- a/skills/build-mode/SKILL.md
+++ b/skills/build-mode/SKILL.md
@@ -1,29 +1,15 @@
 ---
 name: build-mode
-description:
-  Executes roadmaps and requests requiring project modifications with a
-  verification-first mindset. Use when you need to perform write
-  operations and ensure quality standards.
+description: "Edits source files, updates configurations, and runs tests to execute a prepared roadmap or user request. Activates write access, applies changes, verifies with tests/lints/builds, then restores read-only mode. Use when the user says 'build this', 'make these changes', 'implement the plan quickly', or requests codebase modifications, refactoring, or feature implementation."
 ---
 
 # Build mode
 
-**`GOAL`**: Execute project modifications safely and efficiently
-following standard build protocols.
+**`GOAL`**: Execute project modifications safely — activate write access, apply changes, verify correctness, and restore read-only mode.
 
-**`WHEN`**: Invoke this skill when the user requests changes to the
-codebase, refactoring, or feature implementation.
+**`WHEN`**: Invoke this skill when the user requests changes to the codebase, refactoring, or feature implementation.
 
-**`NOTE`**: This skill requires explicit user authorization for
-high-risk operations and always restores read-only mode upon completion.
-
-## Efficiency directives
-
-- Optimize all operations for agent, token, and context efficiency
-- Batch operations on file groups, avoid individual file processing
-- Use parallel execution when possible
-- Target only relevant files
-- Reduce token usage
+**`NOTE`**: Requires explicit user authorization for high-risk operations. Always restores read-only mode upon completion.
 
 ## Task management
 
@@ -41,19 +27,16 @@ high-risk operations and always restores read-only mode upon completion.
   - `ERROR`: Halt and report.
   - `SUCCESS`/`WARN`: Continue.
 
-### Step 2: Execute roadmap
+### Step 2: Execute changes
 
-- Apply the 6-step reasoning engine:
-  1. **Analyze**: Prerequisites and order of operations.
-  2. **Evaluate**: Consequences and risks.
-  3. **Identify**: Likely causes and edge cases.
-  4. **Revise**: Roadmaps based on observations.
-  5. **Incorporate**: All tools, policies, and constraints.
-  6. **Retry**: Transient errors.
-- Follow the risk-adaptive workflow (`TRIVIAL`, `LOW`, `MEDIUM`,
-  `HIGH`).
+- Review the roadmap or request to identify prerequisites and order of operations.
+- Assess risk level for each change:
+  - **TRIVIAL**: Typos, comments, formatting — apply directly.
+  - **LOW**: Single-file edits with clear scope — apply and verify.
+  - **MEDIUM**: Multi-file changes or dependency updates — verify each step before proceeding.
+  - **HIGH**: Architectural changes, security-sensitive code, or data migrations — confirm with user before each major step.
 - Perform modifications.
-- Verify changes through tests, linting, or builds.
+- After each logical group of changes, run the project's test suite, linter, or build command to catch regressions early.
 
 ### Step 3: Restore safety
 
@@ -61,8 +44,7 @@ high-risk operations and always restores read-only mode upon completion.
 
 ### Step 4: Report
 
-- Provide a concise summary of the work completed and verification
-  results.
+- Provide a concise summary of the work completed and verification results.
 - **`DONE`**
 
 ## Output
@@ -72,5 +54,4 @@ high-risk operations and always restores read-only mode upon completion.
 - Project files modified during execution.
 - `.gemini_readonly` - Restored at the end.
 
-**Status communication:** Report summary of modifications and
-verification status.
+**Status communication:** Report summary of modifications and verification status.

--- a/skills/implement-mode/SKILL.md
+++ b/skills/implement-mode/SKILL.md
@@ -1,30 +1,15 @@
 ---
 name: implement-mode
-description:
-  Executes approved roadmaps or requests with a verification-first mindset
-  and robust troubleshooting. Use when you need to implement specific
-  changes and provide a detailed session summary.
+description: "Executes an approved roadmap end-to-end: edits source files, refactors modules, updates configs, runs tests and linters, auto-fixes failures, and produces a detailed session summary. Use when the user says 'implement this', 'execute the plan', 'apply these changes thoroughly', or needs autonomous multi-step code changes with built-in troubleshooting."
 ---
 
-# Implement-Mode
+# Implement mode
 
-**`GOAL`**: Execute approved project modifications safely and
-efficiently following standard implementation protocols.
+**`GOAL`**: Execute an approved roadmap or request end-to-end — activate write access, apply changes, verify and fix, then restore read-only mode and report.
 
-**`WHEN`**: Invoke this skill when the user explicitly requests the
-execution of an approved roadmap or request.
+**`WHEN`**: Invoke this skill when the user explicitly requests execution of an approved roadmap or request with thorough verification.
 
-**`NOTE`**: This skill requires explicit user authorization for
-high-risk operations and always restores read-only mode upon completion.
-
-## Efficiency directives
-
-- Optimize all operations for agent, token, and context efficiency
-- Optimize for minimal output
-- Batch operations on file groups, avoid individual file processing
-- Use parallel execution when possible
-- Target only relevant files
-- Reduce token usage
+**`NOTE`**: Requires explicit user authorization for high-risk operations. Always restores read-only mode upon completion.
 
 ## Task management
 
@@ -47,28 +32,24 @@ high-risk operations and always restores read-only mode upon completion.
 - Initialize the task list using `write_todos`.
 - State the goal, risk level, and management method.
 
-### Step 3: Execute roadmap
+### Step 3: Execute changes
 
-- Apply the 6-step reasoning engine:
-  1. **Analyze**: Prerequisites and order of operations.
-  2. **Evaluate**: Consequences and risks.
-  3. **Identify**: Likely causes and edge cases.
-  4. **Revise**: Roadmaps based on observations.
-  5. **Incorporate**: All tools, policies, and constraints.
-  6. **Retry**: Transient errors.
-- Follow the risk-adaptive workflow (`TRIVIAL`, `LOW`, `MEDIUM`,
-  `HIGH`).
-- Perform modifications.
+- Review the roadmap to identify prerequisites and order of operations.
+- Assess risk level for each change:
+  - **TRIVIAL**: Typos, comments, formatting — apply directly.
+  - **LOW**: Single-file edits with clear scope — apply and verify.
+  - **MEDIUM**: Multi-file changes or dependency updates — verify each step before proceeding.
+  - **HIGH**: Architectural changes, security-sensitive code, or data migrations — confirm with user before each major step.
+- Perform modifications in the determined order.
 
 ### Step 4: Verify & fix
 
-- Run tests, linters, and builds.
+- Run the project's test suite, linter, and build command.
 - **On failure:**
-  1. **Diagnose:** Analyze the error to identify the root cause.
-  2. **Fix:** Attempt to resolve the issue autonomously.
-  3. **Retry:** Verify the fix.
-- **Escalation:** If the issue persists after reasonable attempts, halt
-  and report.
+  1. **Diagnose:** Read the error output to identify the root cause.
+  2. **Fix:** Apply a targeted fix to the failing code.
+  3. **Retry:** Re-run the failing command to confirm the fix.
+- **Escalation:** If the issue persists after three attempts, halt and report the error details to the user.
 
 ### Step 5: Restore safety
 

--- a/skills/prepare-mode/SKILL.md
+++ b/skills/prepare-mode/SKILL.md
@@ -1,42 +1,26 @@
 ---
 name: prepare-mode
-description:
-  Investigates and creates a preparation roadmap to accomplish a task.
-  Use when you need a detailed roadmap for a complex objective.
+description: "Investigates a codebase and produces a structured preparation roadmap with objectives, actionable steps, risk assessment, and verification criteria. Reads source files, maps dependencies, and checks constraints — all in read-only mode. Use when the user says 'plan this', 'prepare a roadmap', 'break this down', 'how should I tackle this', or needs a step-by-step approach before making changes."
 ---
 
 # Prepare mode
 
-**`GOAL`**: Transform vague objectives into actionable, verified
-preparation roadmaps following standard preparation protocols.
+**`GOAL`**: Transform objectives into actionable, verified preparation roadmaps by investigating the codebase and identifying dependencies, risks, and constraints.
 
-**`WHEN`**: Invoke this skill when the user requests a roadmap,
-investigation, or strategic approach for a complex task.
+**`WHEN`**: Invoke this skill when the user requests a roadmap, investigation, or strategic approach for a complex task.
 
-**`NOTE`**: This skill operates strictly in read-only mode to ensure
-safety during investigation.
-
-## Efficiency directives
-
-- Optimize all operations for agent, token, and context efficiency
-- Prefer reading over writing during the preparation phase
-- Batch information gathering to reduce tool calls
-- Target only relevant files
-- Reduce token usage
+**`NOTE`**: Operates strictly in read-only mode to ensure safety during investigation.
 
 ## Confirmation directives
 
-_After_ presenting the preparation roadmap, use the `ask_user` tool to
-offer 4 options:
+_After_ presenting the preparation roadmap, use the `ask_user` tool to offer 4 options:
 
 1. **Review plan** - Invoke the `review-mode` skill for a technical audit
 2. **Quick build** - Invoke the `build-mode` skill for rapid execution
-3. **Implement** - Invoke the `implement-mode` skill for thorough
-   execution
+3. **Implement** - Invoke the `implement-mode` skill for thorough execution
 4. **Abort** - Cancel the workflow and wait for the next instruction
 
-Make option 1 the default response. Assume "Review plan" if the user
-gives an empty response.
+Make option 1 the default response. Assume "Review plan" if the user gives an empty response.
 
 ## Workflow
 
@@ -51,24 +35,24 @@ gives an empty response.
 ### Step 2: Investigate
 
 - Conduct a thorough audit of the request and codebase.
-- **Contextual audit**: Read relevant files, documentation, and logs.
-- **Dependency mapping**: Identify logical dependencies and risks.
-- **Constraint verification**: Verify environment limits and policies.
+- **Contextual audit**: Read README, config files, entry points, documentation, and logs relevant to the objective.
+- **Dependency mapping**: Identify logical dependencies, import chains, and external service calls.
+- **Constraint verification**: Check environment limits, CI requirements, and project policies.
 
 ### Step 3: Draft roadmap
 
-- Create a roadmap following the 8-part structure:
+- Create a roadmap with these 7 sections:
   1. **Objective**: Concise statement of the goal.
   2. **Pre-flight checklist**: Verification steps before starting.
   3. **Strategic approach**: High-level method.
   4. **Actionable steps**: Numbered list of specific operations.
-  5. **Verification roadmap**: How to prove the work's correctness.
-  6. **Risk assessment**: Potential pitfalls and solutions.
+  5. **Verification plan**: How to prove the work's correctness (test commands, expected outputs).
+  6. **Risk assessment**: Potential pitfalls and mitigations.
   7. **Resource requirements**: Tools, files, or permissions needed.
 
 ### Step 4: Analyze & refine
 
-- Perform Multi-perspective analysis:
+- Perform multi-perspective analysis:
   - **The Architect**: Structural integrity and scalability.
   - **The Security Engineer**: Safety, permissions, and vulnerabilities.
   - **The Implementer**: Practicality, efficiency, and clarity.
@@ -85,18 +69,6 @@ gives an empty response.
 - Await user response before further action.
 - **`DONE`**
 
-## Preparation roadmap format
-
-**Preparation roadmap:**
-
-1. **Objective**: [Goal]
-2. **Pre-flight checklist**: [Steps]
-3. **Strategic approach**: [Method]
-4. **Actionable steps**: [List]
-5. **Verification roadmap**: [Proof]
-6. **Risk assessment**: [Pitfalls]
-7. **Resource requirements**: [Needs]
-
 ## Output
 
 **Files created/modified:**
@@ -110,8 +82,7 @@ First line of output indicates user's decision:
 
 - `REVIEW: user wants to review the plan` - user chose review
 - `BUILD: user wants to build the plan` - user chose quick build
-- `IMPLEMENT: user wants to implement the plan` - user chose
-  implementation
+- `IMPLEMENT: user wants to implement the plan` - user chose implementation
 - `ABORT: user cancelled workflow` - user aborted process
 
 **Following lines:** complete preparation roadmap text

--- a/skills/review-mode/SKILL.md
+++ b/skills/review-mode/SKILL.md
@@ -1,44 +1,28 @@
 ---
 name: review-mode
-description:
-  Critically reviews roadmaps, code, and strategies. Use when you need a
-  technical review to identify flaws, risks, and improvements.
+description: "Performs a multi-perspective technical review of roadmaps, code, or architecture — checking for security vulnerabilities, missing edge cases, scalability issues, and regression risks. Produces a structured report with APPROVE, REVISE, or REJECT recommendation. Use when the user says 'review this', 'critique the plan', 'code review', 'find weaknesses', 'red team this', or needs a devil's advocate analysis before implementation."
 ---
 
 # Review mode
 
-**`GOAL`**: Conduct critical technical reviews of roadmaps, code, and
-strategies following standard review protocols.
+**`GOAL`**: Conduct critical technical reviews of roadmaps, code, and strategies — identify flaws, risks, and improvements across security, QA, architecture, performance, and DevOps.
 
-**`WHEN`**: Invoke this skill when the user requests a critical review
-of a roadmap or proposed changes.
+**`WHEN`**: Invoke this skill when the user requests a critical review of a roadmap, code, or proposed changes.
 
-**`NOTE`**: This skill operates strictly in read-only mode to ensure
-safety during analysis.
-
-## Efficiency directives
-
-- Optimize all operations for agent, token, and context efficiency
-- Optimize for minimal output
-- Batch operations on file groups, avoid individual file processing
-- Target only relevant files
-- Reduce token usage
+**`NOTE`**: Operates strictly in read-only mode to ensure safety during analysis.
 
 ## Confirmation directives
 
-_After_ reporting the review decision, use the `ask_user` tool to offer
-4 options:
+_After_ reporting the review decision, use the `ask_user` tool to offer 4 options:
 
 1. **Revise plan** - Invoke the `prepare-mode` skill to address findings
 2. **Quick build** - Invoke the `build-mode` skill for rapid execution
-3. **Implement** - Invoke the `implement-mode` skill for thorough
-   execution
+3. **Implement** - Invoke the `implement-mode` skill for thorough execution
 4. **Abort** - Cancel the workflow and wait for the next instruction
 
 Set the default response based on the review recommendation:
 
-- If recommendation indicates `REVISE` or `REJECT`, make option 1 the
-  default.
+- If recommendation indicates `REVISE` or `REJECT`, make option 1 the default.
 - If recommendation indicates `APPROVE`, make option 2 the default.
 
 ## Workflow
@@ -57,28 +41,22 @@ Set the default response based on the review recommendation:
 
 ### Step 3: Analyze
 
-- Apply the 6-step reasoning engine:
-  1. **Analyze**: Context, objectives, and proposed changes.
-  2. **Evaluate**: Risks from Security, QA, and Ops perspectives.
-  3. **Identify**: Missing edge cases, logical flaws, and debt.
-  4. **Revise**: Understanding based on deep-dive analysis.
-  5. **Incorporate**: `KBase` patterns and project constraints.
-  6. **Retry**: If analysis yields insufficient confidence.
-- Execute Multi-perspective analysis across five viewpoints:
-  - **Security**: Vulnerabilities, permissions, data handling.
-  - **QA**: Test coverage, testability, regression risks.
-  - **Architecture**: Design patterns, scalability, maintainability.
-  - **Performance**: Latency, resource usage, optimization.
-  - **DevOps**: Deployment, monitoring, infrastructure impact.
+- Evaluate the subject across five viewpoints:
+  - **Security**: Vulnerabilities, permissions, data handling, injection risks.
+  - **QA**: Test coverage, testability, regression risks, missing edge cases.
+  - **Architecture**: Design patterns, scalability, maintainability, coupling.
+  - **Performance**: Latency, resource usage, N+1 queries, unnecessary allocations.
+  - **DevOps**: Deployment impact, monitoring gaps, infrastructure changes.
+- Cross-reference findings with `KBase` patterns and project constraints.
 
 ### Step 4: Critique & assess risk
 
-- Compare against `KBase` and best practices.
+- Compare against best practices from `KBase`.
 - Re-evaluate the risk level (`TRIVIAL`, `LOW`, `MEDIUM`, `HIGH`).
 
 ### Step 5: Report
 
-- Output the structured review decision.
+- Output the structured review decision using the format below.
 
 ### Step 6: Confirmation
 
@@ -121,8 +99,7 @@ First line of output indicates user's decision:
 
 - `REVISE: user wants to revise the plan` - user chose revision
 - `BUILD: user wants to build the plan` - user chose quick build
-- `IMPLEMENT: user wants to implement the plan` - user chose
-  implementation
+- `IMPLEMENT: user wants to implement the plan` - user chose implementation
 - `ABORT: user cancelled workflow` - user aborted process
 
 **Following lines:** complete review report text

--- a/skills/write-mode/SKILL.md
+++ b/skills/write-mode/SKILL.md
@@ -1,31 +1,20 @@
 ---
 name: write-mode
-description:
-  Enable write mode by removing the safety marker. Use when the user
-  explicitly authorizes changes.
+description: "Removes the `.gemini_readonly` marker file to unlock write-capable tools (file edits, shell commands, git operations). Runs `scripts/enable-write-mode.sh` and reports SUCCESS, WARN, or ERROR status. Use when the user says 'enable writes', 'make writable', 'unlock editing', or explicitly authorizes file modifications."
 ---
 
 # Write mode
 
-**`GOAL`**: Activate write mode by removing the `.gemini_readonly`
-marker file.
+**`GOAL`**: Activate write mode by removing the `.gemini_readonly` marker file so write-capable tools become available.
 
-**`WHEN`**: Invoke this skill ONLY when the user explicitly authorizes
-write access or requests to disable read-only mode.
+**`WHEN`**: Invoke this skill ONLY when the user explicitly authorizes write access or requests to disable read-only mode.
 
-**`NOTE`**: This skill removes the file that whitelisted hooks use to
-block write-capable tools.
-
-## Efficiency directives
-
-- Optimize all operations for agent, token, and context efficiency
-- Target only relevant files
-- Don't use your task management system for this skill
-- Don't perform a vibe check for this skill
+**`NOTE`**: This skill removes the file that whitelisted hooks use to block write-capable tools.
 
 ## Workflow
 
-- Execute `scripts/enable-write-mode.sh`
+- Execute `scripts/enable-write-mode.sh`.
+- Verify `.gemini_readonly` no longer exists to confirm write mode is active.
 - **`DONE`**
 
 ## Output
@@ -34,4 +23,4 @@ block write-capable tools.
 
 - `.gemini_readonly` - Marker file removed to enable write mode.
 
-**Status communication:** Report status of script operation.
+**Status communication:** Report status of script operation (`SUCCESS`, `WARN` if already active, `ERROR` on failure).


### PR DESCRIPTION
Hey @mystilleef 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/97a9066e-188b-4a4f-86cc-77178a6fbfc5" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| build-mode | 41% | 77% | +36% |
| implement-mode | 41% | 82% | +41% |
| prepare-mode | 52% | 85% | +33% |
| write-mode | 61% | 94% | +33% |
| review-mode | 72% | 85% | +13% |

This PR is intentionally scoped to 5 skills to keep it reviewable — the remaining `readonly-mode` skill (already at 77%) can be improved in a follow-up or via automated review on future PRs.

<details>
<summary>Changes summary</summary>

**All 5 skills:**
- Replaced block scalar descriptions with specific, concrete quoted-string descriptions including natural trigger terms users would actually say (e.g. "build this", "implement the plan", "plan this", "review this")
- Added explicit "Use when..." clauses with real user phrases for better skill selection
- Removed generic "Efficiency directives" sections that restated default agent behavior

**build-mode:**
- Replaced abstract "6-step reasoning engine" with concrete risk-level assessment (TRIVIAL/LOW/MEDIUM/HIGH) with specific actions per level
- Added explicit verification step after each logical group of changes

**implement-mode:**
- Same reasoning engine replacement with concrete risk-level framework
- Made verify & fix step more actionable with explicit 3-attempt escalation policy

**prepare-mode:**
- Fixed "8-part structure" label that only listed 7 items (corrected to "7 sections")
- Removed duplicate roadmap format section that restated Step 3
- Made investigation step more concrete (README, config files, entry points)

**write-mode:**
- Added verification step to confirm `.gemini_readonly` no longer exists after script execution
- Added explicit status codes (SUCCESS, WARN, ERROR) to output documentation

**review-mode:**
- Replaced abstract 6-step reasoning engine with concrete 5-viewpoint analysis (with specific examples like injection risks, N+1 queries)
- Added natural trigger terms: "code review", "find weaknesses", "red team this", "devil's advocate"

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
